### PR TITLE
fix: remove static keyword from preg_ec

### DIFF
--- a/system/database/DB_driver.php
+++ b/system/database/DB_driver.php
@@ -1418,7 +1418,7 @@ abstract class CI_DB_driver {
 			return $item;
 		}
 
-		static $preg_ec = array();
+		$preg_ec = array();
 
 		if (empty($preg_ec))
 		{


### PR DESCRIPTION
This pull request includes a small change to the `system/database/DB_driver.php` file. The change removes the use of a static variable in the `escape_identifiers` function to avoid potential issues with state persistence across function calls.

* [`system/database/DB_driver.php`](diffhunk://#diff-0b9f8acb3624d5b64db974010cd8434941a0fc5bf7dfcdc4e298bde9fa783fb2L1421-R1421): Removed the static keyword from the `$preg_ec` variable in the `escape_identifiers` function to prevent state persistence issues.